### PR TITLE
 fix query of Serverdata (show active players) and store Save inside serverfiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ When you install the server, **run update once to be sure you have the experimen
 - if your connection to the server fails with **"Server is still initializing"** after your gave it 15 min to start(frist start takes a while and should not be interrupted, it can break your save
   - look at the console(toggle console, could be that you need to toggle it three times) or
   - last log (Browse => Server Files => 7DaysToDieServer_Data => the last "output_log_dedi__*.txt")
-  - check if it contains **"SSL certificate problem: unable to get local issuer certificate"**. if yes:
+  - check if it contains **"TLS alert, unknown CA"**. if yes:
     - https://community.7daystodie.com/topic/32449-a21-windows-dedicated-server-eos-error-fix/ 
 
 ## Server Configuration

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ I created this plugin simply to have WindowsGSM host/update from experimental be
 
 ## Importing a server
 The Server World Data is now moved to servers/%ID%/serverfiles/userdata. 
-If you already had a Server running where you want to continue, please move everything from %appdata%\7DaysToDie\ to servers/%ID%/serverfiles/userdata
+If you already had a Server running where you want to continue, please move everything from %appdata%\7DaysToDie\ (just put it in explorer, will expand to C:\Users\YourWindowsUser\AppData\Roaming) 
+=> to WindowsGSM servers/%ID%/serverfiles/userdata (you can find it by marking the server in wgsm and click Browse => Server Files )
 
 then replace `serverconfig.xml`. just make sure to keep:
 <property name="UserDataFolder"		value="userdata" />

--- a/README.md
+++ b/README.md
@@ -14,7 +14,12 @@ then replace the wgsm `serverconfig.xml` with your existing one . just make sure
 When you install the server, **run update once to be sure you have the experimental beta branch**
 
 ### Known issue
-It looks like Windows GSM doesn't specify it is done validating after an update so please wait some time before starting the server. You will receive error `-1073741819` if the update is still in progress.
+- It looks like Windows GSM doesn't specify it is done validating after an update so please wait some time before starting the server. You will receive error `-1073741819` if the update is still in progress.
+- if your connection to the server fails with Server is still initializing after your gave it 15 min to start(frist start takes a while and should not be interrupted, it can break your save
+  - look at the console(toggle console, could be that you need to toggle it three times) or
+  - last log (Browse => Server Files => 7DaysToDieServer_Data => the last "output_log_dedi__*.txt")
+  - check if it contains "SSL certificate problem: unable to get local issuer certificate". if yes:
+    - https://community.7daystodie.com/topic/32449-a21-windows-dedicated-server-eos-error-fix/ 
 
 ## Server Configuration
 In order to configure  the server, please find the `serverconfig.xml` file located in `\serverfiles\serverconfig.xml`

--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ When you install the server, **run update once to be sure you have the experimen
 
 ### Known issue
 - It looks like Windows GSM doesn't specify it is done validating after an update so please wait some time before starting the server. You will receive error `-1073741819` if the update is still in progress.
-- if your connection to the server fails with Server is still initializing after your gave it 15 min to start(frist start takes a while and should not be interrupted, it can break your save
+- if your connection to the server fails with **"Server is still initializing"** after your gave it 15 min to start(frist start takes a while and should not be interrupted, it can break your save
   - look at the console(toggle console, could be that you need to toggle it three times) or
   - last log (Browse => Server Files => 7DaysToDieServer_Data => the last "output_log_dedi__*.txt")
-  - check if it contains "SSL certificate problem: unable to get local issuer certificate". if yes:
+  - check if it contains **"SSL certificate problem: unable to get local issuer certificate"**. if yes:
     - https://community.7daystodie.com/topic/32449-a21-windows-dedicated-server-eos-error-fix/ 
 
 ## Server Configuration

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The Server World Data is now moved to servers/%ID%/serverfiles/userdata.
 If you already had a Server running where you want to continue, please move everything from %appdata%\7DaysToDie\ (just put it in explorer, will expand to C:\Users\YourWindowsUser\AppData\Roaming) 
 => to WindowsGSM servers/%ID%/serverfiles/userdata (you can find it by marking the server in wgsm and click Browse => Server Files )
 
-then replace `serverconfig.xml`. just make sure to keep:
+then replace the wgsm `serverconfig.xml` with your existing one . just make sure to keep/add:
 <property name="UserDataFolder"		value="userdata" />
 
 ## Initial Setup

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ If you already had a Server running where you want to continue, please move ever
 => to WindowsGSM servers/%ID%/serverfiles/userdata (you can find it by marking the server in wgsm and click Browse => Server Files )
 
 then replace the wgsm `serverconfig.xml` with your existing one . just make sure to keep/add:
-<property name="UserDataFolder"		value="userdata" />
+\<property name="UserDataFolder"		value="userdata" />
 
 ## Initial Setup
 When you install the server, **run update once to be sure you have the experimental beta branch**

--- a/README.md
+++ b/README.md
@@ -2,14 +2,22 @@
 
 I created this plugin simply to have WindowsGSM host/update from experimental beta branch.
 
+## Importing a server
+The Server World Data is now moved to servers/%ID%/serverfiles/userdata. 
+If you already had a Server running where you want to continue, please move everything from %appdata%\7DaysToDie\ to servers/%ID%/serverfiles/userdata
+
+then replace `serverconfig.xml`. just make sure to keep:
+<property name="UserDataFolder"		value="userdata" />
+
 ## Initial Setup
-When you install the server, run update once to be sure you have the experimental beta branch
+When you install the server, **run update once to be sure you have the experimental beta branch**
 
 ### Known issue
 It looks like Windows GSM doesn't specify it is done validating after an update so please wait some time before starting the server. You will receive error `-1073741819` if the update is still in progress.
 
 ## Server Configuration
 In order to configure  the server, please find the `serverconfig.xml` file located in `\serverfiles\serverconfig.xml`
+the server will use https://github.com/WindowsGSM/Game-Server-Configs/blob/master/7%20Days%20to%20Die%20Dedicated%20Server/serverconfig.xml as base
 
 ### Notable Fields:
 

--- a/SDTD_ExperimentalBeta.cs/SDTD_ExperimentalBeta.cs
+++ b/SDTD_ExperimentalBeta.cs/SDTD_ExperimentalBeta.cs
@@ -37,8 +37,8 @@ namespace WindowsGSM.Plugins
             name = "WindowsGSM.SDTD_ExperimentalBeta",
             author = "LegendSeeker",
             description = "🧩 WindowsGSM plugin for supporting 7 Days to Die Dedicated Server running Experimental Beta",
-            version = "0.1",
-            url = "https://github.com/LegendSeeker/WindowsGSM.SDTD_ExperimentalBeta",
+            version = "1.0",
+            url = "https://github.com/raziel7893/WindowsGSM.SDTD_ExperimentalBeta",
             color = "#5c1504" // Color Hex
         };
 

--- a/SDTD_ExperimentalBeta.cs/SDTD_ExperimentalBeta.cs
+++ b/SDTD_ExperimentalBeta.cs/SDTD_ExperimentalBeta.cs
@@ -161,22 +161,18 @@ namespace WindowsGSM.Plugins
 
         public async Task Stop(Process p)
         {
-            await Task.Run(() =>
+            await Task.Run(async () =>
             {
                 Functions.ServerConsole.SetMainWindow(p.MainWindowHandle);
-                p.CloseMainWindow();
+                Functions.ServerConsole.SendWaitToMainWindow("^c");
+                Thread.Sleep(500);
                 Functions.ServerConsole.SendWaitToMainWindow("{ENTER}");
+
+                p.CloseMainWindow();
+                Thread.Sleep(1000);
+                if (!p.HasExited)
+                    p.Kill();
             });
-        }
-
-        public new async Task<Process> Install()
-        {
-            var steamCMD = new Installer.SteamCMD();
-
-            Process p = await steamCMD.Install(_serverData.ServerID, string.Empty, AppId);
-            Error = steamCMD.Error;
-
-            return p;
         }
 
         public new async Task<Process> Update(bool validate = false, string custom = null)

--- a/SDTD_ExperimentalBeta.cs/SDTD_ExperimentalBeta.cs
+++ b/SDTD_ExperimentalBeta.cs/SDTD_ExperimentalBeta.cs
@@ -142,8 +142,10 @@ namespace WindowsGSM.Plugins
             if (Directory.Exists(OldProfile))
             {
                 Notice = Notice + $"An Old Savegame found in {OldProfile}\n\n" +
-                        $"If you want to use it, you need to move/copy it manually to \n" +
+                        $"If you want to have it Inside WindowsGSM to have it all in one place move it to\n" +
                         $"servers/{serverData.ServerID}/serverfiles/userdata.\n" +
+                        $"and modify value \"UserDataFolder\" in serverconfig.xml to value \"userdata\"\n" +
+                        $"For More info see the readme of this plugin\n" +
                         $"If this is intentional, ignore this";
             }
 

--- a/SDTD_ExperimentalBeta.cs/SDTD_ExperimentalBeta.cs
+++ b/SDTD_ExperimentalBeta.cs/SDTD_ExperimentalBeta.cs
@@ -61,6 +61,7 @@ namespace WindowsGSM.Plugins
         public new string AppId = "294420";
 
         public SDTD_ExperimentalBeta(ServerConfig serverData) : base(serverData) => base.serverData = _serverData = serverData;
+        public string OldProfile = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "\\7DaysToDie\\Saves");
 
         public async void CreateServerCFG()
         {
@@ -68,6 +69,10 @@ namespace WindowsGSM.Plugins
             string configPath = Functions.ServerPath.GetServersServerFiles(_serverData.ServerID, "serverconfig.xml");
             if (await Functions.Github.DownloadGameServerConfig(configPath, FullName))
             {
+                if (File.Exists(OldProfile))
+                    await UI.CreateYesNoPromptV1("Old server userdata found", $"An Old Savegame found in {OldProfile}\n\n" +
+                        $"If you want to use it, you need to move/copy it manually to \n" +
+                        $"servers/{_serverData.ServerID}/serverfiles/userdata", "Ok", "Ok");
                 string configText = File.ReadAllText(configPath);
                 configText = configText.Replace("{{hostname}}", _serverData.ServerName);
                 configText = configText.Replace("{{rcon_password}}", _serverData.GetRCONPassword());
@@ -98,6 +103,14 @@ namespace WindowsGSM.Plugins
             if (!File.Exists(configPath))
             {
                 Notice = $"serverconfig.xml not found ({configPath})";
+            }
+
+            if (File.Exists(OldProfile))
+            {
+                Notice = $"An Old Savegame found in {OldProfile}\n\n" +
+                        $"If you want to use it, you need to move/copy it manually to \n" +
+                        $"servers/{_serverData.ServerID}/serverfiles/userdata.\n" +
+                        $"If this is intentional, ignore this";
             }
 
             string logFile = @"7DaysToDieServer_Data\output_log_dedi__" + DateTime.Now.ToString("yyyy-MM-dd-HH-mm-ss") + ".txt";

--- a/SDTD_ExperimentalBeta.cs/SDTD_ExperimentalBeta.cs
+++ b/SDTD_ExperimentalBeta.cs/SDTD_ExperimentalBeta.cs
@@ -107,7 +107,7 @@ namespace WindowsGSM.Plugins
             }
 
             string configPath = Functions.ServerPath.GetServersServerFiles(serverData.ServerID, "serverconfig.xml");
-            if (!File.Exists(configPath) && new FileInfo(configPath).Length == 0)
+            if (!File.Exists(configPath) || new FileInfo(configPath).Length == 0)
             {
                 Notice = $"serverconfig.xml not found ({configPath}), reloading it from https://github.com/WindowsGSM/Game-Server-Configs";
                 CreateServerCFG();

--- a/SDTD_ExperimentalBeta.cs/SDTD_ExperimentalBeta.cs
+++ b/SDTD_ExperimentalBeta.cs/SDTD_ExperimentalBeta.cs
@@ -5,6 +5,7 @@ using System;
 using WindowsGSM.Installer;
 using WindowsGSM.GameServer.Engine;
 using WindowsGSM.Functions;
+using WindowsGSM.GameServer.Query;
 
 namespace WindowsGSM.Plugins
 {
@@ -36,7 +37,7 @@ namespace WindowsGSM.Plugins
             author = "LegendSeeker",
             description = "🧩 WindowsGSM plugin for supporting 7 Days to Die Dedicated Server running Experimental Beta",
             version = "0.1",
-            url = "https://github.com/LegendSeeker/WindowsGSM.SDTD_ExperimentalBeta", 
+            url = "https://github.com/LegendSeeker/WindowsGSM.SDTD_ExperimentalBeta",
             color = "#5c1504" // Color Hex
         };
 
@@ -49,7 +50,7 @@ namespace WindowsGSM.Plugins
         public new string StartPath = "7DaysToDieServer.exe";
         public bool AllowsEmbedConsole = true;
         public int PortIncrements = 1;
-        public dynamic QueryMethod = null;
+        public dynamic QueryMethod = new A2S();
 
         public string Port = "26900";
         public string QueryPort = "26900";
@@ -157,7 +158,7 @@ namespace WindowsGSM.Plugins
 
         public new async Task<Process> Install()
         {
-            var steamCMD = new Installer.SteamCMD();            
+            var steamCMD = new Installer.SteamCMD();
 
             Process p = await steamCMD.Install(_serverData.ServerID, string.Empty, AppId);
             Error = steamCMD.Error;
@@ -168,8 +169,8 @@ namespace WindowsGSM.Plugins
         public new async Task<Process> Update(bool validate = false, string custom = null)
         {
             custom = "-beta latest_experimental";
-			validate = true;
-			
+            validate = true;
+
             var (p, error) = await Installer.SteamCMD.UpdateEx(_serverData.ServerID, AppId, validate, custom: custom);
             Error = error;
             return p;

--- a/SDTD_ExperimentalBeta.cs/SDTD_ExperimentalBeta.cs
+++ b/SDTD_ExperimentalBeta.cs/SDTD_ExperimentalBeta.cs
@@ -43,8 +43,8 @@ namespace WindowsGSM.Plugins
 
         public string FullName = "7DTD Dedicated Server - Experimental Beta";
         public override string StartPath => "7DaysToDieServer.exe";
+        public override bool loginAnonymous => true;
         public bool AllowsEmbedConsole = true;
-        public override bool loginAnonymous => false;
         public int PortIncrements = 1;
         public dynamic QueryMethod = new A2S();
 
@@ -107,9 +107,12 @@ namespace WindowsGSM.Plugins
             }
 
             string configPath = Functions.ServerPath.GetServersServerFiles(serverData.ServerID, "serverconfig.xml");
-            if (!File.Exists(configPath))
+            if (!File.Exists(configPath) && new FileInfo(configPath).Length == 0)
             {
-                Notice = $"serverconfig.xml not found ({configPath})";
+                Notice = $"serverconfig.xml not found ({configPath}), reloading it from https://github.com/WindowsGSM/Game-Server-Configs";
+                CreateServerCFG();
+                if (!File.Exists(configPath))
+                    Error = $"ConfigFile is still missing {configPath}";
             }
 
             if (Directory.Exists(OldProfile))

--- a/SDTD_ExperimentalBeta.cs/SDTD_ExperimentalBeta.cs
+++ b/SDTD_ExperimentalBeta.cs/SDTD_ExperimentalBeta.cs
@@ -82,6 +82,10 @@ namespace WindowsGSM.Plugins
                 configText = configText.Replace("{{port}}", serverData.ServerPort);
                 configText = configText.Replace("{{telnetPort}}", (int.Parse(serverData.ServerPort) - int.Parse(Port) + 8081).ToString());
                 configText = configText.Replace("{{maxplayers}}", Maxplayers);
+
+                //it is not good to have the serverdata in %AppData% as the user will forget it, as nearly all windowsgsm servers store it inside the WindosGSM structure
+                //also the backup function would be useless without
+                configText = configText.Replace("<!-- <property name=\"UserDataFolder\"\t\t\t\tvalue=\"absolute path\" /> -->", "<property name=\"UserDataFolder\"\t\t\t\tvalue=\"userdata\" />");
                 File.WriteAllText(configPath, configText);
             }
 


### PR DESCRIPTION
initially i just wanted to fix the QueryMethod, but then a user on the DC brought me to the atention, that the default savegame is stored in AppData which renders the backup function useless, so i adde this aswell.

also updated it to fully use the steamCMD template so the file is a bit cleaner of duplicated functions.

the change is only in install step, as i don't want to mess with existing installs. just added an Info that it can be imported